### PR TITLE
Use == for joins and grouping instead of hashing

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -439,7 +439,7 @@ end
 function _nonmissing!(res, col)
     # workaround until JuliaLang/julia#21256 is fixed
     eltype(col) >: Missing || return
-    
+
     @inbounds for (i, el) in enumerate(col)
         res[i] &= !ismissing(el)
     end
@@ -661,7 +661,7 @@ nonunique(df, 1)
 
 """
 function nonunique(df::AbstractDataFrame)
-    gslots = row_group_slots(df)[3]
+    gslots = row_group_slots(df)[2]
     # unique rows are the first encountered group representatives,
     # nonunique are everything else
     res = fill(true, nrow(df))

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -42,11 +42,6 @@ module TestDataFrameRow
     @test hash(DataFrameRow(df, 2)) == hash(DataFrameRow(df, 5))
     @test hash(DataFrameRow(df, 2)) != hash(DataFrameRow(df, 6))
 
-
-    # check that hashrows() function generates the same hashes as DataFrameRow
-    df_rowhashes, _ = DataFrames.hashrows(df, false)
-    @test df_rowhashes == [hash(dr) for dr in eachrow(df)]
-
     # test incompatible frames
     @test_throws UndefVarError DataFrameRow(df, 1) == DataFrameRow(df3, 1)
 

--- a/test/join.jl
+++ b/test/join.jl
@@ -8,7 +8,7 @@ module TestJoin
 
     const ≅ = isequal
 
-    type TestSum
+    struct TestSum
         x::Integer
         y::Integer
     end


### PR DESCRIPTION
Makes DataFrame joins and grouping use `==` instead of hashing to determine equality.

Making this an internal PR first to see if any improvements can be made before PR'ing against the original source.

As reference: https://github.com/JuliaTime/TimeZones.jl/issues/103
and https://github.com/invenia/Intervals.jl/pull/27/files#diff-493d89206c11fea99259d0771034d26aR173
